### PR TITLE
fix sync bug

### DIFF
--- a/app/jvm/src/main/scala/jbok/app/service/HttpService.scala
+++ b/app/jvm/src/main/scala/jbok/app/service/HttpService.scala
@@ -61,7 +61,7 @@ final class HttpService[F[_]](
         .withNio2(true)
         .enableHttp2(config.enableHttp2)
         .withWebSockets(config.enableWebsockets)
-        .bindHttp(config.port, config.host)
+        .bindHttp(config.port, config.local)
     }
 
     val sslLClientAuthMode = sslConfig.clientAuth match {

--- a/core/jvm/src/main/resources/config.test.yaml
+++ b/core/jvm/src/main/resources/config.test.yaml
@@ -101,7 +101,8 @@ service:
   logBody: true
   enableMetrics: false
   allowedOrigins: []
-  host: localhost
+  local: localhost
+  host: 127.0.0.2
   port: 30315
   apis:
     - account

--- a/core/jvm/src/main/scala/jbok/core/config/NetworkBuilder.scala
+++ b/core/jvm/src/main/scala/jbok/core/config/NetworkBuilder.scala
@@ -45,7 +45,7 @@ final case class NetworkBuilder(
     val config = base
       .lens(_.rootPath).set(rootPath.toAbsolutePath.toString)
       .lens(_.peer.host).set(host)
-      .lens(_.service.host).set(host)
+      .lens(_.service.local).set(host)
       .lens(_.service.enableMetrics).set(true)
 //      .lens(_.service.secure).set(true)
       .lens(_.mining.enabled).set(true)

--- a/core/jvm/src/main/scala/jbok/core/peer/OutgoingManager.scala
+++ b/core/jvm/src/main/scala/jbok/core/peer/OutgoingManager.scala
@@ -57,7 +57,9 @@ final class OutgoingManager[F[_]](config: FullConfig, history: History[F], ssl: 
             peer.queue.dequeue.through(Message.encodePipe).through(socket.writes(None))
           ).parJoinUnbounded
       }
-      .handleErrorWith(e => Stream.sleep(15.seconds) ++ connect(peerUri))
+      .handleErrorWith(e => {
+        Stream.eval(log.error(s"connect ${peerUri.address} error",e)) ++ Stream.sleep(15.seconds) ++ connect(peerUri)
+      })
 
   val connects: Stream[F, Unit] =
     Stream.eval(store.add(config.peer.seedUris: _*)) ++

--- a/core/shared/src/main/scala/jbok/core/config/ServiceConfig.scala
+++ b/core/shared/src/main/scala/jbok/core/config/ServiceConfig.scala
@@ -15,11 +15,12 @@ final case class ServiceConfig(
     logBody: Boolean,
     enableMetrics: Boolean,
     allowedOrigins: List[String],
+    local: String,
     host: String,
     port: Int,
     apis: List[String]
 ) {
-  val addr = new InetSocketAddress(host, port)
+  val addr = new InetSocketAddress(local, port)
 
   val uri: String = (if (secure) "https:" else "http:") + s"//${host}:${port}"
 }


### PR DESCRIPTION
1. Original field 'host' is a local ip like 0.0.0.0, function requestHeaders in SyncClient will call local api. Using field 'host' for external ip, and add field 'local' for binding.
2. Imagine such a situation:Miner A and Miner B restart now, and mined Block(101) in the same time, one of them will be suspended for waiting next block, but the next block will be discarded because of raising a HeaderParentNotFoundInvalid error in function verify.